### PR TITLE
The old User-agend led to a limited result set of 3 results.

### DIFF
--- a/src/dict.cc.py
+++ b/src/dict.cc.py
@@ -16,7 +16,7 @@ class Dict:
 
     def getResponse(self, word):
         # Trick to avoid dict.cc from denying the request: change User-agent to firefox's
-        req = urllib2.Request("http://www.dict.cc/?s="+word, None, {'User-agent': 'Mozilla/5.0'})
+        req = urllib2.Request("http://www.dict.cc/?s="+word, None, {'User-agent': 'Mozilla/6.0'})
         f = urllib2.urlopen(req)
         self.Response = f.read()
 


### PR DESCRIPTION
Changing the user-agent to **6** (or anything but 5) bypasses the dict.cc barrier of 3 results only.

![image](https://cloud.githubusercontent.com/assets/3062564/3798535/d046adcc-1be5-11e4-81ed-ddf85744310d.png)
